### PR TITLE
fix: Enable history mode to add namelink to its path

### DIFF
--- a/src/core/router/history/base.js
+++ b/src/core/router/history/base.js
@@ -45,7 +45,10 @@ export class History {
 
     path = config.alias ? getAlias(path, config.alias) : path;
     path = getFileName(path, ext);
-    path = path === `/README${ext}` ? config.homepage || path : path;
+    path =
+      path === cleanPath(config.nameLink + '/README' + ext)
+        ? cleanPath([config.nameLink, config.homepage].join('/')) || path
+        : path;
     path = isAbsolutePath(path) ? path : getPath(base, path);
 
     if (isRelative) {


### PR DESCRIPTION
## **Summary**

Patching docsify doc path for history mode so that the docs can add {doc}/{slug} to its path to enable the homepage to be loaded dynamically

For example, when homepage is not README.md (e.g., homepage is homepage.md)
Without configuration:
[https://docs.developer.gov.sg/docs/{slug}/README](https://docs.developer.gov.sg/docs/%7Bslug%7D/README) -> 404
With configuration:
[https://docs.developer.gov.sg/docs/{slug}/homepage](https://docs.developer.gov.sg/docs/%7Bslug%7D/homepage) -> load correctly

Expected In docsify history mode, https://docs.developer.gov.sg/docs/{slug}/
 
## **What kind of change does this PR introduce?**
Bugfix

## **Does this PR introduce a breaking change?** (check one)

- [x] No
## **Tested in the following browsers:**

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge
- [x] IE
