### PR TITLE
fix: scroll to target location again on container height change

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@developerportalsg/docsify",
-  "version": "4.12.7",
+  "version": "4.12.8",
   "description": "A magical documentation generator.",
   "author": {
     "name": "qingwei-li",

--- a/src/core/event/index.js
+++ b/src/core/event/index.js
@@ -22,6 +22,24 @@ export function Events(Base) {
         // Scroll to ID if specified
         if (this.route.query.id) {
           scrollIntoView(this.route.path, this.route.query.id);
+          // Continuously observe for height changes in .markdown-section
+          // caused by loading images
+          const resizeObserver = new ResizeObserver(_ => {
+            scrollIntoView(this.route.path, this.route.query.id);
+          });
+          let markdownDiv = document.querySelector('.markdown-section');
+          resizeObserver.observe(markdownDiv);
+          // Stop observing when user manually scrolls
+          const userEvents = ['wheel', 'keydown', 'keyup', 'keypress'];
+          for (const event of userEvents) {
+            document.addEventListener(
+              event,
+              () => {
+                resizeObserver.unobserve(markdownDiv);
+              },
+              { once: true }
+            );
+          }
         }
         // Scroll to top if a link was clicked and auto2top is enabled
         if (source === 'navigate') {


### PR DESCRIPTION
<!--
  PULL REQUEST TEMPLATE
  ---
  Please use English language
  Please don't delete this template
  ---
  Update "[ ]" to "[x]" to check a box in any list below.
  ---
  To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.
-->

## **Summary**

<!--
 THIS IS REQUIRED! Please describe what the change does and why it should be merged.
-->
Continuously observe for container height changes, then re-fires `scrollIntoView` function to the target section. This will point to the target's updated location. Finally on user input, stop observing for height changes.
<!--
  If changing the UI in any way, please provide the a **before/after** screenshot:
-->

## **What kind of change does this PR introduce?**

<!--
  Copy/paste one of the following options:
-->
Bugfix
<!--
  Bugfix
  Feature
  Code style update
  Refactor
  Docs
  Build-related changes
  Repo settings
  Other
-->

<!--
  If you chose Other, please describe.
-->

## **For any code change,**

- [x] Related documentation has been updated if needed
- [x] Related tests have been updated or tests have been added

## **Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

## **Related issue, if any:**

<!-- Paste issue's link or number hashtag here. -->

## **Tested in the following browsers:**

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE
